### PR TITLE
Refactor levelOfDifficulty function in game.js. Closes #87.

### DIFF
--- a/lib/game.js
+++ b/lib/game.js
@@ -208,22 +208,22 @@ function levelOfDifficulty() {
   if(points() < 500) {
     displayLevel(1);
   }
-  else if(points() >= 500 && points() <= 999) {
+  if(points() >= 500 && points() <= 999) {
     levelUp(2);
   }
-  else if (points() >= 1000 && points() <= 1499) {
+  if (points() >= 1000 && points() <= 1499) {
     levelUp(3);
   }
-  else if (points() >= 1500 && points() <= 1999) {
+  if (points() >= 1500 && points() <= 1999) {
     levelUp(4);
   }
-  else if (points() >= 2000 && points() <= 2499) {
+  if (points() >= 2000 && points() <= 2499) {
     levelUp(5);
   }
-  else if (points() >= 2500 && points() <= 2999) {
+  if (points() >= 2500 && points() <= 2999) {
     levelUp(6);
   }
-  else if (points() >= 3000 && points() <= 4000) {
+  if (points() >= 3000 && points() <= 4000) {
     levelUp(7);
   }
 }

--- a/lib/game.js
+++ b/lib/game.js
@@ -13,7 +13,7 @@ let asteroidReady = false;
 let asteroid = new Image();
 
 asteroid.onload = function () {
-    asteroidReady = true;
+  asteroidReady = true;
 };
 
 asteroid.src = "asteroid.png";
@@ -22,7 +22,7 @@ let starReady = false;
 let star = new Image();
 
 star.onload = function () {
-    starReady = true;
+  starReady = true;
 };
 
 star.src = "star.png";
@@ -194,53 +194,37 @@ function points() {
   return score.currentScore(parsecs)
 }
 
+function displayLevel(level) {
+  context.font = "30px Bangers";
+  context.fillText(`Level: ${level}`, 600, 30);
+}
+
+function levelUp(level) {
+  increaseSpeed();
+  displayLevel(level);
+}
+
 function levelOfDifficulty() {
   if(points() < 500) {
-    context.font = "30px Bangers";
-    context.fillText("Level: 1", 600, 30);
+    displayLevel(1);
   }
   else if(points() >= 500 && points() <= 999) {
-    increaseSpeed();
-    // if(points() >= 500 && points() < 1000) {
-      context.font = "30px Bangers";
-      context.fillText("Level: 2", 600, 30);
-    // }
+    levelUp(2);
   }
   else if (points() >= 1000 && points() <= 1499) {
-    increaseSpeed();
-    // if(points() >= 1000 && points() < 1500) {
-      context.font = "30px Bangers";
-      context.fillText("Level: 3", 600, 30);
-    // }
+    levelUp(3);
   }
   else if (points() >= 1500 && points() <= 1999) {
-    increaseSpeed();
-    // if(points() >= 1500 && points() < 2000) {
-      context.font = "30px Bangers";
-      context.fillText("Level: 4", 600, 30);
-    // }
+    levelUp(4);
   }
   else if (points() >= 2000 && points() <= 2499) {
-    increaseSpeed();
-    // if(points() >= 2000 && points() < 2500) {
-      context.font = "30px Bangers";
-      context.fillText("Level: 5", 600, 30);
-    // }
+    levelUp(5);
   }
   else if (points() >= 2500 && points() <= 2999) {
-    increaseSpeed();
-    // if(points() >= 2500 && points() < 3000) {
-      context.font = "30px Bangers";
-      context.fillText("Level: 6", 600, 30);
-    // }
+    levelUp(6);
   }
   else if (points() >= 3000 && points() <= 4000) {
-    speed = speed + .02
-    parsecs += .1
-    // if(points() >= 3000 && points() < 4000) {
-      context.font = "30px Bangers";
-      context.fillText("Level: 7", 600, 30);
-    // }
+    levelUp(7);
   }
 }
 


### PR DESCRIPTION
@dtinianow @neight-allen
This PR extracts the logic from levelOfDifficultyFunction into two additional functions.  The first, is the displayLevel function which accepts the level and displays the level.  The second, levelUp function, increases the game speed and calls the displayLevel function.  This is necessary because we only want to increase game speed after completing level 1.

Please review these three functions in game.js, or view files changed: `levelOfDifficulty()`, `displayLevel()`, and `levelUp()`.

If you would like to manually test this, you can clone the repo, cd into the repo, run `$npm install`, run `$ npm start`,  visit http://localhost:8080/webpack-dev-server/, and play the game until you reach above 500 points.  If you exceed 500 points, the level should change to level 2.

David, please let me know if you think this is an appropriate solution to breaking up the levelOfDifficulty function.  Thanks.
