### PR TITLE
Refactor end game win game. Closes #89

### DIFF
--- a/lib/game.js
+++ b/lib/game.js
@@ -29,16 +29,21 @@ star.src = "star.png";
 
 let ufo = new Ufo({x: 230, y: 60, width: 50, height: 20, isFlying: false});
 
-let topObstacle = new Obstacle({x: canvas.width, y: 100, width: 50, height: 50});
-let bottomObstacle = new Obstacle({x: canvas.width, y: canvas.height-200, width: 50, height: 50});
-let topObstacle_2 = new Obstacle({x: canvas.width+600, y: 200, width: 50, height: 50});
-let bottomObstacle_2 = new Obstacle({x: canvas.width+600, y: canvas.height-300, width: 50, height: 50});
-let topObstacle_3 = new Obstacle({x: canvas.width+600, y: 0, width: 50, height: 50});
-let bottomObstacle_3 = new Obstacle({x: canvas.width+600, y: canvas.height-75, width: 50, height: 50});
-let topObstacle_4 = new Obstacle({x: canvas.width, y: 0, width: 50, height: 50});
-let bottomObstacle_4 = new Obstacle({x: canvas.width, y: canvas.height-75, width: 50, height: 50});
-let topObstacle_5 = new Obstacle({x: canvas.width+600, y: 0, width: 50, height: 50});
-let bottomObstacle_5 = new Obstacle({x: canvas.width+600, y: canvas.height-75, width: 50, height: 50});
+const obstacleWidth = 50
+const obstacleHeight = 50
+const canvasWidth = canvas.width
+const canvasWidthOffset = canvas.width + 600
+
+let topObstacle = new Obstacle({x: canvasWidth, y: 100, width: obstacleWidth, height: obstacleHeight});
+let bottomObstacle = new Obstacle({x: canvasWidth, y: canvas.height-200, width: obstacleWidth, height: obstacleHeight});
+let topObstacle_2 = new Obstacle({x: canvasWidthOffset, y: 200, width: obstacleWidth, height: obstacleHeight});
+let bottomObstacle_2 = new Obstacle({x: canvasWidthOffset, y: canvas.height-300, width: obstacleWidth, height: obstacleHeight});
+let topObstacle_3 = new Obstacle({x: canvasWidthOffset, y: 0, width: obstacleWidth, height: obstacleHeight});
+let bottomObstacle_3 = new Obstacle({x: canvasWidthOffset, y: canvas.height-75, width: obstacleWidth, height: obstacleHeight});
+let topObstacle_4 = new Obstacle({x: canvasWidth, y: 0, width: obstacleWidth, height: obstacleHeight});
+let bottomObstacle_4 = new Obstacle({x: canvasWidth, y: canvas.height-75, width: obstacleWidth, height: obstacleHeight});
+let topObstacle_5 = new Obstacle({x: canvasWidthOffset, y: 0, width: obstacleWidth, height: obstacleHeight});
+let bottomObstacle_5 = new Obstacle({x: canvasWidthOffset, y: canvas.height-75, width: obstacleWidth, height: obstacleHeight});
 
 let obstacles = [topObstacle, bottomObstacle, topObstacle_2, bottomObstacle_2, topObstacle_3, bottomObstacle_3, topObstacle_4, bottomObstacle_4, topObstacle_5, bottomObstacle_5];
 
@@ -60,7 +65,6 @@ $(function() {
 });
 
 function startGame() {
-  // window.removeEventListener('keydown', replayFunction);
   ui.showStartScreen()
   loadStartButton();
   window.addEventListener('keydown', spacebarFunction);
@@ -104,27 +108,25 @@ function stopListeningForKey() {
 }
 
 function endGame() {
-  stopListeningForKey();
   ui.showEndScreen();
-  score.appendScores('#end-screen', parsecs);
-  score.saveGameScores(parsecs);
-  score.showGameScores('#game-over-top-scores');
-  ui.reloadPageToStart('#replay-button');
-  setTimeout(function() {
-    window.addEventListener('keydown', replayFunction);
-  }, 1200);
+  setFinalScreen('#end-screen', '#game-over-top-scores', '#replay-button')
 }
 
 function winGame() {
-  stopListeningForKey();
   ui.showWinScreen();
-  score.appendScores('#win-screen', parsecs);
+  setFinalScreen('#win-screen', '#you-won-top-scores', '#restart-button')
+}
+
+function setFinalScreen(screenId, scoresId, buttonId) {
+  stopListeningForKey();
+  score.appendScores(screenId, parsecs);
   score.saveGameScores(parsecs);
-  score.showGameScores('#you-won-top-scores');
-  ui.reloadPageToStart('#restart-button');
+  score.showGameScores(scoresId);
+  ui.reloadPageToStart(buttonId);
   setTimeout(function() {
     window.addEventListener('keydown', replayFunction);
   }, 1200);
+
 }
 
 function beginGame() {


### PR DESCRIPTION
@neight-allen @twhitinger 

This PR extracts the logic from the endGame and winGame functions to the setFinalScreen function. The reduces duplication of code and improves readability.

Please review the following functions: `endGame()`, `winGame` and `setFinalScreen`.

If you would like to manually test this, you can clone the repo, cd into the repo, run $npm install, run $ npm start, visit http://localhost:8080/webpack-dev-server/, and play the game until you win and/or lose. All scores should be visible.

@twhitinger, please review the refactor and comment on the changes.
